### PR TITLE
Support site announcements

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,40 @@ make build
 
 ## Projects
 
+Projects are managed as Markdown pages under `projects/pages/` with `layout: page_project` and front-matter metadata. The Projects index (`projects/index.html`) builds a list from all pages with `parent: Projects` using `_includes/page_tree_builder.html` + `_includes/list_projects.html` and renders a card-style list.
+
+Key front-matter fields:
+
+- `title`, `description`, `permalink`, `parent: Projects`, `navbar_active: Projects`
+- `nav_order` controls sort order (lower `nav_order` appears first on the index; the list is reversed in the include for implementation)
+- `thumb` is the thumbnail shown on the listing
+- Optional: `link_url`, `link_caption`, `api_url`, `gallery` + `gallery_images`, `resources` + `resource_list`
+
+To add a new project, create a new file in `projects/pages/` with the fields above. The listing and detail page are generated automatically.
+
 ## News
 
+News items are primarily managed via portal.ce.pdn.ac.lk's [News API](https://portal.ce.pdn.ac.lk/api/news/v2/pera-swarm/). To add a news item, create a new entry in the CE portal with the appropriate fields and tenant set to `Pera-Swarm`. The website fetches news from the API and generates Markdown pages under `news/pages/` using the `python_scripts/update_news.py` Python script (runs daily). The API is the source of truth; Markdown pages are regenerated from the API data, so manual edits to those pages will be overwritten.
+
 ## Publications
+
+Publications are managed as Markdown pages under `publications/` with `layout: page_publication` and front-matter metadata. The Publications index (`publications/index.html`) uses `_includes/page_tree_builder.html` + `_includes/list_publications.html` to list pages where `parent: Publications` in reverse order.
+
+- `paper_title`, `published_at`, `doi`
+- `authors_list` (array of `{ name, profile }`)
+- Optional: `pdf`, `presentation`, `source_code`
+- Standard fields: `title`, `permalink`, `parent: Publications`, `navbar_active: Publications`, `nav_order`
+
+To add a publication, create a new Markdown file in `publications/` with those fields. The list page renders the citation, DOI link, and any provided resource links.
+
+## People
+
+People profiles are managed by the following JSON files:
+
+- `_data/team.json`
+- `_data/supervisors.json`
+
+Those files will be automatically updated by the Python script, `python_scripts/update.py` (runs daily), based on the API URL provided in the project page's front-matter. Team and Supervisors lists will be obtained from CE API Portal's [Projects API](https://api.ce.pdn.ac.lk/docs/projects/).
 
 ## Announcements
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Those files will be automatically updated by the Python script, `python_scripts/
 
 ## Announcements
 
-Site-wide announcements are rendered via the Jekyll include at `_includes/announcements.html`, which is included at the top of all layouts. The include fetches announcements from `https://portal.ce.pdn.ac.lk/api/announcements/v2/pera-swarm`, renders Bootstrap alerts, and filters by `starts_at`/`ends_at` (inclusive) plus `area` set to `both` or `frontend`.
+Site-wide announcements are rendered via the Jekyll include at `_includes/announcements.html`. Most layouts display announcements through the shared navbar include, while some minimal layouts (such as blank or home-style layouts) include `announcements.html` directly at the top of the page. Each layout should include announcements exactly once (either via the navbar or directly) to avoid duplicate alerts. The include fetches announcements from `https://portal.ce.pdn.ac.lk/api/announcements/v2/pera-swarm`, renders Bootstrap alerts, and filters by `starts_at`/`ends_at` (inclusive) plus `area` set to `both` or `frontend`.
 
 Caching behavior:
 

--- a/README.md
+++ b/README.md
@@ -41,3 +41,27 @@ Additionally, the below commands can be used to build the site without serving i
 ```bash
 make build
 ```
+
+## Projects
+
+## News
+
+## Publications
+
+## Announcements
+
+Site-wide announcements are rendered via the Jekyll include at `_includes/announcements.html`, which is included at the top of all layouts. The include fetches announcements from `https://portal.ce.pdn.ac.lk/api/announcements/v2/pera-swarm`, renders Bootstrap alerts, and filters by `starts_at`/`ends_at` (inclusive) plus `area` set to `both` or `frontend`.
+
+Caching behavior:
+
+- Cookie name: `announcements`
+- Cache validity: 30 minutes based on `fetched_at`
+- Cookie expiration: 30 minutes
+
+If the cookie is missing or invalid (including JSON parse errors), the include re-fetches the API. Invalid responses or failed requests render nothing and do not break page rendering.
+
+Security and compliance notes:
+
+- Rate-limits: client-side cache prevents repeated fetches within 30 minutes and reduces load on the API.
+- Input validation: only renders announcements with valid `type`, `message`, `starts_at`, and `ends_at` fields.
+- Secret management: no secrets are stored or required by the include.

--- a/_includes/announcements.html
+++ b/_includes/announcements.html
@@ -68,17 +68,17 @@
       }
       try {
         var parsed = JSON.parse(raw);
-        if (!parsed || typeof parsed !== "object") {
-          return null;
-        }
-        if (typeof parsed.fetched_at !== "number") {
+        if (!parsed || typeof parsed !== "object" || typeof parsed.fetched_at !== "number") {
           return null;
         }
         if (nowMs() - parsed.fetched_at > CACHE_VALID_MS) {
+          // Expired, clear it
+          clearCookie(COOKIE_NAME);
           return null;
         }
         return parsed;
       } catch (err) {
+        // Invalid, clear it
         clearCookie(COOKIE_NAME);
         return null;
       }
@@ -133,7 +133,9 @@
           return true;
         })
         .map(function (item) {
-          return `<div class="alert ${TYPE_CLASS[item.type]} w-100 mb-0 rounded-0 py-2 d-flex align-items-center" role="alert">${TYPE_ICON[item.type]}<div>${item.message}</div></div>`;
+          // Escape message content to avoid unsafe HTML
+          const message = $("<div>").text(item.message).html();
+          return `<div class="alert ${TYPE_CLASS[item.type]} w-100 mb-0 rounded-0 py-2 d-flex align-items-center" role="alert">${TYPE_ICON[item.type]}<div>${message}</div></div>`;
         })
         .join("");
       if (!html) {

--- a/_includes/announcements.html
+++ b/_includes/announcements.html
@@ -53,11 +53,12 @@
     function setCookie(name, value, ttlMs) {
       var expires = new Date(nowMs() + ttlMs).toUTCString();
       document.cookie =
-        name + "=" + encodeURIComponent(value) + "; expires=" + expires + "; path=/; SameSite=Lax";
+        name + `=${encodeURIComponent(value)}; expires=${expires}; path=/; SameSite=Lax; Secure`;
     }
 
     function clearCookie(name) {
-      document.cookie = name + "=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; SameSite=Lax";
+      document.cookie =
+        name + "=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; SameSite=Lax; Secure";
     }
 
     function readCache() {

--- a/_includes/announcements.html
+++ b/_includes/announcements.html
@@ -16,6 +16,15 @@
       warning: "alert-warning",
       success: "alert-success",
     };
+    var TYPE_ICON = {
+      info: '<i class="fa fa-info-circle me-2" aria-hidden="true"></i><span class="visually-hidden">Info:</span>',
+      danger:
+        '<i class="fa fa-exclamation-triangle me-2" aria-hidden="true"></i><span class="visually-hidden">Danger:</span>',
+      warning:
+        '<i class="fa fa-exclamation-triangle me-2" aria-hidden="true"></i><span class="visually-hidden">Warning:</span>',
+      success:
+        '<i class="fa fa-check-circle me-2" aria-hidden="true"></i><span class="visually-hidden">Success:</span>',
+    };
 
     function nowMs() {
       return Date.now ? Date.now() : new Date().getTime();
@@ -123,7 +132,7 @@
           return true;
         })
         .map(function (item) {
-          return `<div class="alert ${TYPE_CLASS[item.type]} w-100 mb-0 rounded-0 py-2" role="alert">${item.message}</div>`;
+          return `<div class="alert ${TYPE_CLASS[item.type]} w-100 mb-0 rounded-0 py-2 d-flex align-items-center" role="alert">${TYPE_ICON[item.type]}<div>${item.message}</div></div>`;
         })
         .join("");
       if (!html) {

--- a/_includes/announcements.html
+++ b/_includes/announcements.html
@@ -1,0 +1,168 @@
+<div id="announcements-container" class="p-0 w-100"></div>
+<script>
+  (function () {
+    if (typeof window.jQuery === "undefined") {
+      return;
+    }
+
+    var $ = window.jQuery;
+    var API_URL = "https://portal.ce.pdn.ac.lk/api/announcements/v2/pera-swarm";
+    var COOKIE_NAME = "announcements";
+    var CACHE_VALID_MS = 30 * 60 * 1000;
+    var COOKIE_TTL_MS = 30 * 60 * 1000;
+    var TYPE_CLASS = {
+      info: "alert-info",
+      danger: "alert-danger",
+      warning: "alert-warning",
+      success: "alert-success",
+    };
+
+    function nowMs() {
+      return Date.now ? Date.now() : new Date().getTime();
+    }
+
+    function parseDate(value) {
+      var date = new Date(value);
+      if (isNaN(date.getTime())) {
+        return null;
+      }
+      return date;
+    }
+
+    function getCookie(name) {
+      var nameEq = name + "=";
+      var parts = document.cookie.split(";");
+      for (var i = 0; i < parts.length; i += 1) {
+        var part = parts[i].trim();
+        if (part.indexOf(nameEq) === 0) {
+          return decodeURIComponent(part.substring(nameEq.length));
+        }
+      }
+      return null;
+    }
+
+    function setCookie(name, value, ttlMs) {
+      var expires = new Date(nowMs() + ttlMs).toUTCString();
+      document.cookie =
+        name + "=" + encodeURIComponent(value) + "; expires=" + expires + "; path=/; SameSite=Lax";
+    }
+
+    function clearCookie(name) {
+      document.cookie = name + "=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; SameSite=Lax";
+    }
+
+    function readCache() {
+      var raw = getCookie(COOKIE_NAME);
+      if (!raw) {
+        return null;
+      }
+      try {
+        var parsed = JSON.parse(raw);
+        if (!parsed || typeof parsed !== "object") {
+          return null;
+        }
+        if (typeof parsed.fetched_at !== "number") {
+          return null;
+        }
+        if (nowMs() - parsed.fetched_at > CACHE_VALID_MS) {
+          return null;
+        }
+        return parsed;
+      } catch (err) {
+        clearCookie(COOKIE_NAME);
+        return null;
+      }
+    }
+
+    function normalizeItems(payload) {
+      if (!payload || !Array.isArray(payload.data)) {
+        return [];
+      }
+      return payload.data;
+    }
+
+    function render(payload) {
+      var items = normalizeItems(payload);
+      if (!items.length) {
+        return;
+      }
+      var now = new Date();
+      const html = items
+        .filter(function (item) {
+          // Filter out invalid items
+          if (!item || typeof item !== "object") {
+            return false;
+          }
+
+          if (!TYPE_CLASS[item.type]) {
+            return false;
+          }
+
+          if (typeof item.message !== "string" || item.message.length === 0) {
+            return false;
+          }
+          return true;
+        })
+        .filter(function (item) {
+          // Filter by date time
+          var startsAt = parseDate(item.starts_at);
+          var endsAt = parseDate(item.ends_at);
+          if (!startsAt || !endsAt) {
+            return false;
+          }
+
+          if (now < startsAt || now > endsAt) {
+            return false;
+          }
+
+          var area = item.area;
+          if (area !== "both" && area !== "frontend") {
+            return false;
+          }
+
+          return true;
+        })
+        .map(function (item) {
+          return `<div class="alert ${TYPE_CLASS[item.type]} w-100 mb-0 rounded-0 py-2" role="alert">${item.message}</div>`;
+        })
+        .join("");
+      if (!html) {
+        return;
+      }
+      $("#announcements-container").html(html);
+    }
+
+    $(function () {
+      var cached = readCache();
+      if (cached && cached.response) {
+        render(cached.response);
+        return;
+      }
+
+      $.ajax({
+        url: API_URL,
+        method: "GET",
+        dataType: "json",
+        timeout: 10000,
+      })
+        .done(function (response) {
+          if (!response || !Array.isArray(response.data)) {
+            return;
+          }
+          setCookie(
+            COOKIE_NAME,
+            JSON.stringify({
+              url: API_URL,
+              fetched_at: nowMs(),
+              response: response,
+            }),
+            COOKIE_TTL_MS
+          );
+          render(response);
+        })
+        .fail(function () {
+          return;
+        });
+    });
+  })();
+</script>

--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -1,3 +1,4 @@
+{% include announcements.html %}
 <nav class="navbar sticky-top navbar-expand-lg navbar-dark bg-dark">
   <div class="container px-5">
     {% if page.layout != "home" -%}

--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -1,4 +1,6 @@
-{% include announcements.html %}
+<!-- Announcement Display -->
+{%- if include.announcements != false -%} {% include announcements.html %} {%- endif -%}
+<!-- Navbar -->
 <nav class="navbar sticky-top navbar-expand-lg navbar-dark bg-dark">
   <div class="container px-5">
     {% if page.layout != "home" -%}

--- a/_layouts/blank.html
+++ b/_layouts/blank.html
@@ -12,6 +12,7 @@ layout: wrappers_table
 </head>
 
 <body>
+    {% include announcements.html %}
     <div class="container vh-75">
         <div class="row">
             <div class="container col-sm-12 col-md-10 col-lg-10 mx-auto mt-3 py-2">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -11,6 +11,7 @@ layout: wrappers_table
 </head>
 
 <body>
+    {% include announcements.html %}
     {% include navbar.html %}
     <div class="container vh-75">
         <div class="row">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -11,7 +11,6 @@ layout: wrappers_table
 </head>
 
 <body>
-    {% include announcements.html %}
     {% include navbar.html %}
     <div class="container vh-75">
         <div class="row">

--- a/_layouts/empty.html
+++ b/_layouts/empty.html
@@ -12,6 +12,7 @@ layout: wrappers_table
 </head>
 
 <body>
+    {% include announcements.html %}
     <div class="container vh-75">
         <div class="row">
             <div class="container col-sm-12 col-md-10 col-lg-10 mx-auto mt-3 py-2">

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -14,6 +14,7 @@ layout: wrappers_table
 </head>
 
 <body>
+    {% include announcements.html %}
     <header class="blog-header pb-1">
         <div class="container">
             <div class="row flex-nowrap0 align-items-center">
@@ -67,8 +68,7 @@ layout: wrappers_table
     </div>
 
     {% include navbar.html %}
-
-    <div class="container vh-75">
+        <div class="container vh-75">
         <div class="row">
             <div class="container col-sm-12 col-md-10 col-lg-10 mx-auto mt-3 py-2">
                 {{ content }}

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -3,7 +3,7 @@ layout: wrappers_table
 ---
 
 <!DOCTYPE html>
-<html lang="{{ site.lang | default: "en-US" }}">
+<html lang="{{ site.lang | default: 'en-US' }}">
 <head>
     {% include meta.html %}
 
@@ -67,8 +67,8 @@ layout: wrappers_table
         </button>
     </div>
 
-    {% include navbar.html %}
-        <div class="container vh-75">
+    {% include navbar.html announcements=false %}
+    <div class="container vh-75">
         <div class="row">
             <div class="container col-sm-12 col-md-10 col-lg-10 mx-auto mt-3 py-2">
                 {{ content }}

--- a/_layouts/none.html
+++ b/_layouts/none.html
@@ -12,6 +12,7 @@ layout: wrappers_table
 </head>
 
 <body>
+    {% include announcements.html %}
     <div class="container vh-75">
         <div class="row">
             <div class="container col-sm-12 col-md-10 col-lg-10 mx-auto mt-3 py-2">


### PR DESCRIPTION
Adds a site-wide announcement system that fetches and displays announcements from the CE Portal API. The announcements appear as Bootstrap alert banners at the top of pages, with client-side caching to minimize API requests.

Changes:
- Added _includes/announcements.html with JavaScript to fetch, cache, and render announcements from an external API
- Updated all main layouts (home, default, blank, empty, none) and navbar include to display announcements
- Documented the announcements feature in README.md